### PR TITLE
Retention policies and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,22 +134,37 @@ They can be found in each project page under the tab Policy.
 
 ```json
 [
-    {
-        "scope": "1",
-        "schedule": "Daily",
-        "rules": [
+  {
+    "scope": {
+      "level": "project",
+      "ref": 2
+    },
+    "rules": [
+      {
+        "template": "always",
+        "tag_selectors": [
+          {
+            "decoration": "matches",
+            "pattern": "master"
+          }
+        ],
+        "scope_selectors":  {
+          "repository": [
             {
-                "n_days_since_last_pull": 5,
-                "repo_matching": "**",
-                "tag_matching": "latest"
-            },
-            {
-                "n_days_since_last_push": 5,
-                "repo_matching": "**",
-                "tag_matching": "{latest,snapshot}"
+              "kind": "doublestar",
+              "decoration": "repoMatches",
+              "pattern": "**"
             }
-        ]
+          ]
+        }
+      }
+    ],
+    "trigger": {
+      "settings": {
+        "cron": "0 0 0 * * *"
+      }
     }
+  }
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ A list of projects and their metadata.
 ### purge-job-schedule.json
 
 The schedule of the purge job, there can always only be one.
+The purge job schedule can be found in the page "Clean Up" under the tab "Log Rotation".
 
 ```json
 {
@@ -110,6 +111,7 @@ The schedule of the purge job, there can always only be one.
 ### garbage-collection-schedule.json
 
 The schedule of the garbage collection, there can always only be one.
+The garbage collection schedule can be found in the page "Clean Up" under the tab "Garbage Collection".
 
 ```json
 {
@@ -122,6 +124,33 @@ The schedule of the garbage collection, there can always only be one.
         "type": "Custom"
     }
 }
+```
+
+### retention-policies.json
+
+Definition of the retention policies.
+The retention policies can be set per project.
+They can be found in each project page under the tab Policy.
+
+```json
+[
+    {
+        "scope": "1",
+        "schedule": "Daily",
+        "rules": [
+            {
+                "n_days_since_last_pull": 5,
+                "repo_matching": "**",
+                "tag_matching": "latest"
+            },
+            {
+                "n_days_since_last_push": 5,
+                "repo_matching": "**",
+                "tag_matching": "{latest,snapshot}"
+            }
+        ]
+    }
+]
 ```
 
 ### registries.json

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ A list of projects and team members with their respective roles.
 ### projects.json
 
 A list of projects and their metadata.
+Projects can also be used as Proxy Caches. In that case, they have to refer to the `registry_id` of an existing registry.
+The `registry_id` can be found in the registry definitions in the `registries.json` file.
 
 ```json
 [
@@ -85,6 +87,15 @@ A list of projects and their metadata.
             "auto_scan": true
         },
         "storage_limit": -1
+    },
+    {
+        "project_name": "Proxy Cache",
+        "metadata": {
+            "public": "true",
+            "auto_scan": "false"
+        },
+        "storage_limit": -1,
+        "registry_id": 1
     }
 ]
 ```
@@ -131,6 +142,10 @@ The garbage collection schedule can be found in the page "Clean Up" under the ta
 Definition of the retention policies.
 The retention policies can be set per project.
 They can be found in each project page under the tab Policy.
+`scope.ref` refers to the `project_id` (integer) this retention policy should be associated with.
+This `project_id` can be found in the url of each project. For example:
+`Project 1` has the url `https://harbor-url.com/harbor/projects/`**`2`**`/repositories`. That means the `project_id` of `Project 1` is `2`.
+
 
 ```json
 [
@@ -175,11 +190,13 @@ They can be found in each project page under the tab Policy.
 ### registries.json
 
 All information about registries.
+All registries have an `id`, wheather implicitly or explicitly set.
 
 ```json
 [
     {
         "name": "registry.io",
+        "id": 1,
         "url": "https://registry.io",
         "type": "docker-registry",
         "description": "Example docker registry."

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The purge job schedule can be found in the page "Clean Up" under the tab "Log Ro
         "include_operations": "create,delete,pull"
     },
     "schedule": {
-        "cron": "0 0 0 * * *",
+        "cron": "53 0 0 * * *",
         "type": "Custom"
     }
 }
@@ -120,7 +120,7 @@ The garbage collection schedule can be found in the page "Clean Up" under the ta
         "workers": 1
     },
     "schedule": {
-        "cron": "0 0 0 * * *",
+        "cron": "47 0 0 * * *",
         "type": "Custom"
     }
 }
@@ -135,24 +135,27 @@ They can be found in each project page under the tab Policy.
 ```json
 [
   {
+    "algorithm": "or",
     "scope": {
       "level": "project",
       "ref": 2
     },
     "rules": [
       {
+	"action": "retain",
         "template": "always",
         "tag_selectors": [
           {
             "decoration": "matches",
-            "pattern": "master"
+	    "kind": "doublestar",
+            "pattern": "**"
           }
         ],
         "scope_selectors":  {
           "repository": [
             {
-              "kind": "doublestar",
               "decoration": "repoMatches",
+              "kind": "doublestar",
               "pattern": "**"
             }
           ]
@@ -160,8 +163,9 @@ They can be found in each project page under the tab Policy.
       }
     ],
     "trigger": {
+      "kind": "Schedule",
       "settings": {
-        "cron": "0 0 0 * * *"
+        "cron": "43 0 0 * * *"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The purge job schedule can be found in the page "Clean Up" under the tab "Log Ro
         "include_operations": "create,delete,pull"
     },
     "schedule": {
-        "cron": "53 0 0 * * *",
+        "cron": "0 53 0 * * *",
         "type": "Custom"
     }
 }
@@ -120,7 +120,7 @@ The garbage collection schedule can be found in the page "Clean Up" under the ta
         "workers": 1
     },
     "schedule": {
-        "cron": "47 0 0 * * *",
+        "cron": "0 47 0 * * *",
         "type": "Custom"
     }
 }
@@ -165,7 +165,7 @@ They can be found in each project page under the tab Policy.
     "trigger": {
       "kind": "Schedule",
       "settings": {
-        "cron": "43 0 0 * * *"
+        "cron": "0 43 0 * * *"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ This `project_id` can be found in the url of each project. For example:
 ### registries.json
 
 All information about registries.
-All registries have an `id`, wheather implicitly or explicitly set.
+All registries have an `id`, whether implicitly or explicitly set.
 
 ```json
 [

--- a/src/harbor.py
+++ b/src/harbor.py
@@ -199,7 +199,7 @@ async def sync_retention_policies(retention_policies: [RetentionPolicy]):
             )
             print("Updating retention policy")
             await client.update_retention_policy(
-                retention_scope,
+                project_retention_id,
                 retention_policy
             )
         except Exception as e:

--- a/src/harbor.py
+++ b/src/harbor.py
@@ -197,19 +197,16 @@ async def sync_retention_policies(retention_policies: [RetentionPolicy]):
             project_retention_id = await client.get_project_retention_id(
                 retention_scope
             )
-            if project_retention_id is None:
-                print("Creating retention policy")
-                await client.create_retention_policy(
-                    retention_policy_to_create
-                )
-            else:
-                print("Updating retention policy")
-                await client.update_retention_policy(
-                    retention_scope,
-                    retention_policy
-                )
+            print("Updating retention policy")
+            await client.update_retention_policy(
+                retention_scope,
+                retention_policy
+            )
         except Exception as e:
-            print("Error syncing retention policies")
+            print("Creating retention policy")
+            await client.create_retention_policy(
+                retention_policy_to_create
+            )
 
 
 async def sync_harbor_config(harbor_config: Configurations):

--- a/src/harbor.py
+++ b/src/harbor.py
@@ -197,13 +197,13 @@ async def sync_retention_policies(retention_policies: [RetentionPolicy]):
             project_retention_id = await client.get_project_retention_id(
                 retention_scope
             )
-            print("Updating retention policy")
             await client.update_retention_policy(
                 project_retention_id,
                 retention_policy
             )
+            print("Updating retention policy for scope " + retention_scope)
         except Exception as e:
-            print("Creating retention policy")
+            print("Creating retention policy for scope " + retention_scope)
             await client.create_retention_policy(
                 retention_policy
             )

--- a/src/harbor.py
+++ b/src/harbor.py
@@ -201,9 +201,11 @@ async def sync_retention_policies(retention_policies: [RetentionPolicy]):
                 project_retention_id,
                 retention_policy
             )
-            print(f"Updating retention policy for project with id {retention_scope}")
+            print(f"Updating retention policy for project with id "
+                  f"{retention_scope}")
         except Exception as e:
-            print(f"Creating retention policy for project with id {retention_scope}")
+            print(f"Creating retention policy for project with id "
+                  f"{retention_scope}")
             await client.create_retention_policy(
                 retention_policy
             )

--- a/src/harbor.py
+++ b/src/harbor.py
@@ -192,7 +192,7 @@ async def sync_purge_job_schedule(purge_job_schedule: Schedule) -> None:
 
 async def sync_retention_policies(retention_policies: [RetentionPolicy]):
     for retention_policy in retention_policies:
-        retention_scope = retention_policy.scope
+        retention_scope = retention_policy["scope"]
         try:
             project_retention_id = await client.get_project_retention_id(
                 retention_scope

--- a/src/harbor.py
+++ b/src/harbor.py
@@ -201,9 +201,9 @@ async def sync_retention_policies(retention_policies: [RetentionPolicy]):
                 project_retention_id,
                 retention_policy
             )
-            print("Updating retention policy for scope " + retention_scope)
+            print(f"Updating retention policy for scope {retention_scope}")
         except Exception as e:
-            print("Creating retention policy for scope " + retention_scope)
+            print(f"Creating retention policy for scope {retention_scope}")
             await client.create_retention_policy(
                 retention_policy
             )

--- a/src/harbor.py
+++ b/src/harbor.py
@@ -192,7 +192,7 @@ async def sync_purge_job_schedule(purge_job_schedule: Schedule) -> None:
 
 async def sync_retention_policies(retention_policies: [RetentionPolicy]):
     for retention_policy in retention_policies:
-        retention_scope = retention_policy["scope"]
+        retention_scope = retention_policy["scope"]["ref"]
         try:
             project_retention_id = await client.get_project_retention_id(
                 retention_scope

--- a/src/harbor.py
+++ b/src/harbor.py
@@ -199,7 +199,9 @@ async def sync_retention_policies(retention_policies: [RetentionPolicy]):
             )
             if project_retention_id is None:
                 print("Creating retention policy")
-                await client.create_retention_policy(retention_policy_to_create)
+                await client.create_retention_policy(
+                    retention_policy_to_create
+                )
             else:
                 print("Updating retention policy")
                 await client.update_retention_policy(

--- a/src/harbor.py
+++ b/src/harbor.py
@@ -207,12 +207,14 @@ async def sync_retention_policies(retention_policies: [RetentionPolicy]):
     # Update retention policies
     for retention_policy_to_update in retention_policies_to_update:
         retention_id = retention_policy_to_update.id
+        print("Updating retention policy")
         await client.update_retention_policy(
             retention_id,
             retention_policy_to_update
         )
     # Create retention policies
     for retention_policy_to_create in retention_policies_to_create:
+        print("Creating retention policy")
         await client.create_retention_policy(retention_policy_to_create)
 
 

--- a/src/harbor.py
+++ b/src/harbor.py
@@ -205,7 +205,7 @@ async def sync_retention_policies(retention_policies: [RetentionPolicy]):
         except Exception as e:
             print("Creating retention policy")
             await client.create_retention_policy(
-                retention_policy_to_create
+                retention_policy
             )
 
 

--- a/src/harbor.py
+++ b/src/harbor.py
@@ -201,9 +201,9 @@ async def sync_retention_policies(retention_policies: [RetentionPolicy]):
                 project_retention_id,
                 retention_policy
             )
-            print(f"Updating retention policy for scope {retention_scope}")
+            print(f"Updating retention policy for project with id {retention_scope}")
         except Exception as e:
-            print(f"Creating retention policy for scope {retention_scope}")
+            print(f"Creating retention policy for project with id {retention_scope}")
             await client.create_retention_policy(
                 retention_policy
             )


### PR DESCRIPTION
The pull requests corrects the way retention policies were handled before. A working example is added to the `README.md`. In order to make it easier to differentiate between purge jobs, garbage collection and retention policies a description where to find each in the Web UI is added.