### PR TITLE
Chainguard wolfi-base image as base for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /install
 COPY requirements.txt requirements.txt
 # we want always the latest version of fetched pip packages
 # hadolint ignore=DL3013
-RUN pip3 install --no-cache-dir setuptools wheel && \
+RUN pip3 install --no-cache-dir -U pip setuptools wheel && \
     pip3 install --no-cache-dir --prefix=/install --no-warn-script-location -r ./requirements.txt
 
 FROM builder AS native-builder
@@ -24,7 +24,7 @@ COPY src/ /src/
 RUN python -m venv /venv && \
     /venv/bin/pip install --no-cache-dir -U pip nuitka setuptools wheel && \
     /venv/bin/pip install --no-cache-dir --no-warn-script-location -r ./requirements.txt && \
-    /venv/bin/python -m nuitka --onefile --clean-cache=all /src/harbor.py && \
+    /venv/bin/python -m nuitka --onefile /src/harbor.py && \
     pwd && \
     ls -lha
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-alpine@sha256:5049c050bdc68575a10bcb1885baa0689b6c15152d8a56a7e399fb49f783bf98 AS base
+#FROM cgr.dev/chainguard/wolfi-base:latest AS base
 ENV PYTHONUNBUFFERED=1
 
 FROM base AS builder
@@ -6,6 +7,7 @@ FROM base AS builder
 # hadolint ignore=DL3018
 RUN apk add --no-cache build-base libressl-dev musl-dev libffi-dev && \
     mkdir /install
+#RUN apk add python-3.12 python3-dev py3.12-pip
 WORKDIR /install
 COPY requirements.txt requirements.txt
 # we want always the latest version of fetched pip packages
@@ -31,5 +33,6 @@ COPY tests/ /tests/
 WORKDIR /tests
 RUN python3 -m unittest discover -v -s .
 
-FROM alpine:3.20@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a
+#FROM alpine:3.20@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a
+FROM cgr.dev/chainguard/wolfi-base:latest
 COPY --from=native-builder /install/harbor.bin /usr/local/harbor

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.12-alpine@sha256:5049c050bdc68575a10bcb1885baa0689b6c15152d8a56a7e
 ENV PYTHONUNBUFFERED=1
 
 FROM base AS builder
+RUN apk update && apk upgrade
 # we want always the latest version of fetched apk packages
 # hadolint ignore=DL3018
 RUN apk add --no-cache build-base libressl-dev musl-dev libffi-dev && \
@@ -23,7 +24,7 @@ COPY src/ /src/
 RUN python -m venv /venv && \
     /venv/bin/pip install --no-cache-dir -U pip nuitka setuptools wheel && \
     /venv/bin/pip install --no-cache-dir --no-warn-script-location -r ./requirements.txt && \
-    /venv/bin/python -m nuitka --onefile /src/harbor.py && \
+    /venv/bin/python -m nuitka --onefile --clean-cache=all /src/harbor.py && \
     pwd && \
     ls -lha
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# Always use the latest image
+# hadolint ignore=DL3007
 FROM cgr.dev/chainguard/wolfi-base:latest AS base
 ENV PYTHONUNBUFFERED=1
 
@@ -6,7 +8,9 @@ FROM base AS builder
 # hadolint ignore=DL3018
 RUN apk add --no-cache build-base openssl-dev glibc-dev posix-libc-utils libffi-dev && \
     mkdir /install
-RUN apk add python-3.12 python3-dev py3.12-pip
+# we want always the latest version of fetched apk packages
+# hadolint ignore=DL3018
+RUN apk add --no-cache python-3.12 python3-dev py3.12-pip
 WORKDIR /install
 COPY requirements.txt requirements.txt
 # we want always the latest version of fetched pip packages
@@ -32,5 +36,7 @@ COPY tests/ /tests/
 WORKDIR /tests
 RUN python3 -m unittest discover -v -s .
 
+# Always use the latest image
+# hadolint ignore=DL3007
 FROM cgr.dev/chainguard/wolfi-base:latest
 COPY --from=native-builder /install/harbor.bin /usr/local/harbor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-FROM python:3.12-alpine@sha256:5049c050bdc68575a10bcb1885baa0689b6c15152d8a56a7e399fb49f783bf98 AS base
-#FROM cgr.dev/chainguard/wolfi-base:latest AS base
+FROM cgr.dev/chainguard/wolfi-base:latest AS base
 ENV PYTHONUNBUFFERED=1
 
 FROM base AS builder
-RUN apk update && apk upgrade
 # we want always the latest version of fetched apk packages
 # hadolint ignore=DL3018
-RUN apk add --no-cache build-base libressl-dev musl-dev libffi-dev && \
+RUN apk add --no-cache build-base openssl-dev glibc-dev posix-libc-utils libffi-dev && \
     mkdir /install
-#RUN apk add python-3.12 python3-dev py3.12-pip
+RUN apk add python-3.12 python3-dev py3.12-pip
 WORKDIR /install
 COPY requirements.txt requirements.txt
 # we want always the latest version of fetched pip packages
@@ -34,6 +32,5 @@ COPY tests/ /tests/
 WORKDIR /tests
 RUN python3 -m unittest discover -v -s .
 
-#FROM alpine:3.20@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a
 FROM cgr.dev/chainguard/wolfi-base:latest
 COPY --from=native-builder /install/harbor.bin /usr/local/harbor

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /install
 COPY requirements.txt requirements.txt
 # we want always the latest version of fetched pip packages
 # hadolint ignore=DL3013
-RUN pip3 install --no-cache-dir -U pip setuptools wheel && \
+RUN pip3 install --no-cache-dir setuptools wheel && \
     pip3 install --no-cache-dir --prefix=/install --no-warn-script-location -r ./requirements.txt
 
 FROM builder AS native-builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,9 @@ ENV PYTHONUNBUFFERED=1
 FROM base AS builder
 # we want always the latest version of fetched apk packages
 # hadolint ignore=DL3018
-RUN apk add --no-cache build-base openssl-dev glibc-dev posix-libc-utils libffi-dev && \
+RUN apk add --no-cache build-base openssl-dev glibc-dev posix-libc-utils libffi-dev \
+    python-3.12 python3-dev py3.12-pip && \
     mkdir /install
-# we want always the latest version of fetched apk packages
-# hadolint ignore=DL3018
-RUN apk add --no-cache python-3.12 python3-dev py3.12-pip
 WORKDIR /install
 COPY requirements.txt requirements.txt
 # we want always the latest version of fetched pip packages

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-harborapi==0.26.0
+harborapi==0.25.3
 python-json-logger==2.0.7
 chevron==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-harborapi==0.26.1
+harborapi==0.26.0
 python-json-logger==2.0.7
 chevron==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-harborapi==0.25.3
+harborapi==0.24.2
 python-json-logger==2.0.7
 chevron==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 harborapi==0.26.1
 python-json-logger==2.0.7
 chevron==0.14.0
+httpx==0.27.2 # temporal fix of harborapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-harborapi==0.24.2
+harborapi==0.26.1
 python-json-logger==2.0.7
 chevron==0.14.0

--- a/src/registries.py
+++ b/src/registries.py
@@ -47,5 +47,8 @@ async def sync_registries(client, path, logger):
             )
         # Create new registry
         else:
-            logger.info("Creating new registry", extra={target_registry_name})
+            logger.info(
+                "Creating new registry",
+                extra={"registry": target_registry_name}
+            )
             await client.create_registry(registry=target_registry)


### PR DESCRIPTION
This pull request exchanges the python/ubuntu and alpine images in the Dockerfile for the wolfi-base image (see https://github.com/wolfi-dev). This was requested in #58 .
As the wolfi-base image is very restrictive with dependencies / packages, some of the dependencies needed to be changed in order to be able to build with nuitka. Especially the dependency `dll` caused issues as building the `harbor.bin` from python code also involves building its dependencies like `harborapi`.