### PR TITLE
Remove pinned httpx version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 harborapi==0.26.1
 python-json-logger==2.0.7
 chevron==0.14.0
-httpx==0.27.2 # temporal fix of harborapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-harborapi==0.26.1
+harborapi==0.26.2
 python-json-logger==2.0.7
 chevron==0.14.0


### PR DESCRIPTION
Remove the pin of httpx as the relating issue was fixed in `harborapi==0.26.2`.